### PR TITLE
Improve wind stat chart rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains **ha-wind-stat-card**, a simple Home Assistant custom c
 - `wind_gust` – gust sensor
 - `wind_dir` – wind direction sensor
 
-The card fetches history for the configured timeframe (default: 1 hour) and displays stacked bars over the full width. An arrow below the chart indicates the current wind direction. Colors and bar rendering follow the style of `ha_wf_card` if present.
+The card fetches history for the configured timeframe (default: 1 hour) and displays up to 60 stacked bars over the full width. You can change the number of bars with the optional `samples` option. An arrow below the chart indicates the current wind direction. Colors and bar rendering follow the style of `ha_wf_card` if present.
 
 ## Usage
 
@@ -27,6 +27,7 @@ wind_speed: sensor.wind_speed
 wind_gust: sensor.wind_gust
 wind_dir: sensor.wind_direction
 hours: 1  # optional timeframe
+samples: 60  # optional number of bars
 ```
 
 The card updates whenever all three sensors provide new values.

--- a/info.md
+++ b/info.md
@@ -1,5 +1,5 @@
 # ha_wind_stat_card
 
-A simple Home Assistant custom card that displays wind speed, gust, and direction as a stacked bar chart with an arrow for current direction. The card fetches history for the configured timeframe and updates whenever all three sensors update.
+A simple Home Assistant custom card that displays wind speed, gust, and direction as a stacked bar chart with an arrow for current direction. The card fetches history for the configured timeframe and shows up to 60 bars by default. You can adjust this with the `samples` option. The card updates whenever all three sensors update.
 
 See the repository README for installation and configuration details.


### PR DESCRIPTION
## Summary
- add `samples` option to limit history points
- sample history data when building the chart
- document the new option

## Testing
- `node -c ha-wind-stat-card.js`

------
https://chatgpt.com/codex/tasks/task_e_686a7110a298832880242bf3cac409bb