### PR TITLE
Switch wind card from table to vertical list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ha_wind_stat_card
 
-This repository contains **ha-wind-stat-card**, a Home Assistant custom card that displays the last 10 wind measurements in a simple table. It uses three entities:
+This repository contains **ha-wind-stat-card**, a Home Assistant custom card that displays the last 10 wind measurements in a vertical list. It uses three entities:
 
 - `wind_speed` – wind speed sensor
 - `wind_gust` – gust sensor
 - `wind_dir` – wind direction sensor
 
-The card fetches history for these entities and shows the most recent 10 entries. The first table row contains `speed/gust` pairs and the second row lists the corresponding wind direction values.
+The card fetches history for these entities and shows the most recent 10 entries. Each list item contains the `speed/gust` pair followed by the corresponding wind direction.
 
 ## Usage
 

--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -13,13 +13,14 @@ class HaWindStatCard extends HTMLElement {
           display: block;
           padding: 16px;
         }
-        table {
+        .list {
+          display: flex;
+          flex-direction: column;
           width: 100%;
-          border-collapse: collapse;
-          text-align: center;
         }
-        td {
-          padding: 4px;
+        .entry {
+          padding: 4px 0;
+          text-align: center;
         }
       `;
       this.appendChild(style);
@@ -51,32 +52,19 @@ class HaWindStatCard extends HTMLElement {
       return;
     }
     const startIndex = Math.max(points - 10, 0);
-    const row1Values = [];
-    const row2Values = [];
+    const list = document.createElement('div');
+    list.className = 'list';
     for (let i = startIndex; i < points; i++) {
       const spd = speedHist[i].state;
       const gst = gustHist[i].state;
       const dir = dirHist[i].state;
-      row1Values.push(`${spd}/${gst}`);
-      row2Values.push(dir);
+      const item = document.createElement('div');
+      item.className = 'entry';
+      item.textContent = `${spd}/${gst} - ${dir}`;
+      list.appendChild(item);
     }
-    const table = document.createElement('table');
-    const row1 = document.createElement('tr');
-    row1Values.forEach(v => {
-      const td = document.createElement('td');
-      td.textContent = v;
-      row1.appendChild(td);
-    });
-    const row2 = document.createElement('tr');
-    row2Values.forEach(v => {
-      const td = document.createElement('td');
-      td.textContent = v;
-      row2.appendChild(td);
-    });
-    table.appendChild(row1);
-    table.appendChild(row2);
     this.content.innerHTML = '';
-    this.content.appendChild(table);
+    this.content.appendChild(list);
   }
 
   getCardSize() {

--- a/info.md
+++ b/info.md
@@ -1,5 +1,5 @@
 # ha_wind_stat_card
 
-A Home Assistant custom card that lists the last 10 wind speed, gust and direction values in a two-row table. The first row shows `speed/gust` for each entry, while the second row shows the wind direction. The card pulls history data for the configured sensors and updates automatically.
+A Home Assistant custom card that lists the last 10 wind speed, gust and direction values in a vertical list. Each entry displays the `speed/gust` pair followed by the wind direction. The card pulls history data for the configured sensors and updates automatically.
 
 See the repository README for installation and configuration details.


### PR DESCRIPTION
## Summary
- switch CSS to use flex column layout
- display wind entries in a list instead of a table
- update documentation to mention the new vertical list layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686a8d32848083288cde971269f4e064