### PR TITLE
Use per-minute averages for wind statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ha_wind_stat_card
 
-This repository contains **ha-wind-stat-card**, a Home Assistant custom card that displays the last 10 wind measurements in a vertical list. It uses three entities:
+This repository contains **ha-wind-stat-card**, a Home Assistant custom card that displays the last 10 minutes of wind statistics in a vertical list. It uses three entities:
 
 - `wind_speed` – wind speed sensor
 - `wind_gust` – gust sensor
 - `wind_dir` – wind direction sensor
 
-The card fetches history for these entities and shows the most recent 10 entries. Each list item contains the `speed/gust` pair followed by the corresponding wind direction.
+The card fetches history for these entities, calculates the average value for each minute, and shows the most recent 10 minutes. Each list item contains the `speed/gust` pair followed by the corresponding wind direction.
 
 ## Usage
 

--- a/info.md
+++ b/info.md
@@ -1,5 +1,5 @@
 # ha_wind_stat_card
 
-A Home Assistant custom card that lists the last 10 wind speed, gust and direction values in a vertical list. Each entry displays the `speed/gust` pair followed by the wind direction. The card pulls history data for the configured sensors and updates automatically.
+A Home Assistant custom card that lists the last 10 minutes of wind speed, gust and direction values in a vertical list. Each entry displays the `speed/gust` pair followed by the wind direction. The card pulls history data for the configured sensors, calculates per-minute averages and updates automatically.
 
 See the repository README for installation and configuration details.


### PR DESCRIPTION
## Summary
- calculate averages for each minute instead of raw history values
- combine data without matching timestamps
- update README and info accordingly

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ab8d752108328aebd025eb92305cd