### PR TITLE
Add configurable display window

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # ha_wind_stat_card
 
-This repository contains **ha-wind-stat-card**, a Home Assistant custom card that shows the last 10 minutes of wind statistics as a small bar graph. Each minute is represented as a column where the wind speed is drawn as a bar and the gust height is stacked on top. A small arrow rotated in the direction of the wind replaces the numeric direction. The card uses three entities:
+This repository contains **ha-wind-stat-card**, a Home Assistant custom card that shows the last minutes of wind statistics (30 by default) as a small bar graph. Each minute is represented as a column where the wind speed is drawn as a bar and the gust height is stacked on top. A small arrow rotated in the direction of the wind replaces the numeric direction. The card uses three entities:
 
 - `wind_speed` – wind speed sensor
 - `wind_gust` – gust sensor
 - `wind_dir` – wind direction sensor
 
-The card fetches history for these entities, calculates the average value for each minute, and shows the most recent 10 minutes. Each list item contains the `speed/gust` pair followed by the corresponding wind direction.
+The card fetches history for these entities, calculates the average value for each minute, and shows the most recent configured number of minutes (30 by default). Each list item contains the `speed/gust` pair followed by the corresponding wind direction.
 
 ## Usage
 
@@ -26,6 +26,8 @@ type: 'custom:ha-wind-stat-card'
 wind_speed: sensor.wind_speed
 wind_gust: sensor.wind_gust
 wind_dir: sensor.wind_direction
+# Optional: number of minutes to display (defaults to 30)
+minutes: 45
 ```
 
 The card automatically updates when new history data is available.

--- a/info.md
+++ b/info.md
@@ -1,5 +1,5 @@
 # ha_wind_stat_card
 
-A Home Assistant custom card that displays the last 10 minutes of wind data as a small bar graph. Wind speed is drawn as a bar for each minute with gust height stacked on top. A rotated arrow indicates the wind direction. The card pulls history for the configured sensors, calculates per-minute averages and updates automatically.
+A Home Assistant custom card that displays the last minutes of wind data (30 by default) as a small bar graph. Wind speed is drawn as a bar for each minute with gust height stacked on top. A rotated arrow indicates the wind direction. The card pulls history for the configured sensors, calculates per-minute averages and updates automatically.
 
 See the repository README for installation and configuration details.


### PR DESCRIPTION
## Summary
- allow customizing the number of minutes displayed
- fetch enough history based on configured minutes
- document the new `minutes` option

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ad465caec8328a586bd28db4f72ee