### PR TITLE
Adjust arrow layout and fill bars

### DIFF
--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -14,7 +14,7 @@ class HaWindStatCard extends HTMLElement {
       style.textContent = `
         :host {
           display: block;
-          padding: 16px;
+          padding: 16px 0;
         }
         .graph {
           display: flex;
@@ -32,8 +32,9 @@ class HaWindStatCard extends HTMLElement {
         }
         .bars {
           position: relative;
-          width: 100%;
+          width: calc(100% - 2px);
           height: 80px;
+          margin: 0 1px;
         }
         .bar {
           position: absolute;
@@ -48,10 +49,11 @@ class HaWindStatCard extends HTMLElement {
           background: rgba(255, 152, 0, 0.7);
         }
         .arrow {
-          width: 12px;
+          width: calc(100% - 2px);
           height: 12px;
-          margin-bottom: 2px;
+          margin: 0 1px 2px;
           transform-origin: center;
+          display: block;
         }
       `;
       this.appendChild(style);
@@ -146,7 +148,7 @@ class HaWindStatCard extends HTMLElement {
       const arrow = document.createElement('ha-icon');
       arrow.className = 'arrow';
       arrow.setAttribute('icon', 'mdi:navigation');
-      arrow.style.transform = `rotate(${dir}deg)`;
+      arrow.style.transform = `rotate(${dir + 180}deg)`;
       minute.appendChild(arrow);
 
       const bars = document.createElement('div');


### PR DESCRIPTION
## Summary
- fill card width by removing horizontal padding
- align arrow with bars and allow 1px side margins
- rotate wind arrow 180 degrees

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686adb0c01248328af52f2c4e58e7404