### PR TITLE
Add animated wind bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ha_wind_stat_card
 
-This repository contains **ha-wind-stat-card**, a Home Assistant custom card that shows the last minutes of wind statistics (30 by default) as a small bar graph. Each minute is represented as a column where the wind speed is drawn as a bar and the gust height is stacked on top. A small arrow rotated in the direction of the wind replaces the numeric direction. The card uses three entities:
+This repository contains **ha-wind-stat-card**, a Home Assistant custom card that shows the last minutes of wind statistics (30 by default) as a small bar graph. Each minute is represented as a column where the wind speed is drawn as a bar and the gust height is stacked on top. Bars always fill the width of the card and animate when new data arrives. A small arrow rotated in the direction of the wind replaces the numeric direction. The card uses three entities:
 
 - `wind_speed` – wind speed sensor
 - `wind_gust` – gust sensor

--- a/info.md
+++ b/info.md
@@ -1,5 +1,5 @@
 # ha_wind_stat_card
 
-A Home Assistant custom card that displays the last minutes of wind data (30 by default) as a small bar graph. Wind speed is drawn as a bar for each minute with gust height stacked on top. A rotated arrow indicates the wind direction. The card pulls history for the configured sensors, calculates per-minute averages and updates automatically.
+A Home Assistant custom card that displays the last minutes of wind data (30 by default) as a small bar graph. Wind speed is drawn as a bar for each minute with gust height stacked on top. Bars fill the width of the card and animate when new data arrives. A rotated arrow indicates the wind direction. The card pulls history for the configured sensors, calculates per-minute averages and updates automatically.
 
 See the repository README for installation and configuration details.


### PR DESCRIPTION
## Summary
- animate wind bars and navigation arrow when data updates
- make bars automatically fill the width of the card
- document new behaviour

## Testing
- `node -e "require('./ha-wind-stat-card.js')"` *(fails: HTMLElement is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_686bb950b74c83288de1db2b3f26b4ad