### PR TITLE
Add direction arrows and grid lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,12 @@ The card loads data through the Home Assistant history API and refreshes itself 
 - Stacked bars showing wind speed with gusts on top
 - Y‑axis from 0–60 kn with grid lines every 5 kn (only up to current max gust)
 - Auto refreshes once per minute and shows the last updated time
-- Works with two sensors configured in YAML:
+- Direction arrows for each minute showing averaged wind direction
+- Markers every 5 minutes below the graph
+- Works with three sensors configured in YAML:
   - `wind_entity`
   - `gust_entity`
+  - `direction_entity`
 - Fallback message when no data is available
 
 ## Usage
@@ -32,6 +35,7 @@ resources:
 type: 'custom:ha-wind-stat-card'
 wind_entity: sensor.wind_speed
 gust_entity: sensor.wind_gust
+direction_entity: sensor.wind_direction
 # Optional number of minutes (defaults to 30)
 minutes: 45
 ```

--- a/info.md
+++ b/info.md
@@ -2,4 +2,4 @@
 
 A minimal Lovelace card that shows recent wind data as stacked bars. Wind speed forms the base of each bar with gusts stacked above. Data is loaded via the Home Assistant history API, averaged per minute and refreshed automatically every 60 seconds.
 
-Configure the card with `wind_entity` and `gust_entity` sensors. See the README for installation and usage instructions.
+Configure the card with `wind_entity`, `gust_entity` and `direction_entity` sensors. See the README for installation and usage instructions.


### PR DESCRIPTION
## Summary
- support a `direction_entity`
- display rotation-corrected arrows above each bar
- show markers every 5 minutes under the graph
- render grid lines every 5 knots
- document new configuration

## Testing
- `node --check ha-wind-stat-card.js`


------
https://chatgpt.com/codex/tasks/task_e_686cddbc930c8328985e62d69577a4ea