### PR TITLE
Fix arrow alignment and remove 5m markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The card loads data through the Home Assistant history API and refreshes itself 
 - Y‑axis from 0–60 kn with grid lines every 5 kn (only up to current max gust)
 - Auto refreshes once per minute and shows the last updated time
 - Direction arrows for each minute showing averaged wind direction
-- Markers every 5 minutes below the graph
 - Works with three sensors configured in YAML:
   - `wind_entity`
   - `gust_entity`

--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -201,9 +201,6 @@ class HaWindStatCard extends LitElement {
               style="background:${colorGust};height:1px;margin-bottom:${gustHeight}px;width:100%;"
             ></div>`
           : null}
-        ${(this._data.length - 1 - index) % 5 === 0
-          ? html`<div class="minute-marker"></div>`
-          : null}
       </div>
     `;
   }
@@ -263,15 +260,7 @@ class HaWindStatCard extends LitElement {
       display: block;
       text-align: center;
       transform-origin: center center;
-      margin-bottom: 2px;
-    }
-    .minute-marker {
-      position: absolute;
-      bottom: -4px;
-      left: 0;
-      width: 100%;
-      height: 2px;
-      background: var(--secondary-text-color);
+      margin-bottom: 0;
     }
     .h-line {
       position: absolute;


### PR DESCRIPTION
## Summary
- remove the 5 minute graph markers
- line up the arrow icon with the base of the windspeed bar

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d2602e5008328ac9ffab0f90f2d30