### PR TITLE
Fix initial bar and overlay wind direction

### DIFF
--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -127,7 +127,8 @@ class HaWindStatCard extends LitElement {
 
       const data = [];
       let max = 0;
-      for (let i = minutes - 1; i >= 0; i--) {
+      // Skip the first minute as it often has no data yet
+      for (let i = minutes - 2; i >= 0; i--) {
         const mTime = new Date(now.getTime() - i * 60000);
         const key = mTime.toISOString().slice(0, 16);
 
@@ -255,12 +256,15 @@ class HaWindStatCard extends LitElement {
     }
     .dir-icon {
       --mdc-icon-size: 100%;
+      position: absolute;
+      bottom: 0;
+      left: 0;
       width: 100%;
       height: 1em;
       display: block;
       text-align: center;
+      pointer-events: none;
       transform-origin: center center;
-      margin-bottom: 0;
     }
     .h-line {
       position: absolute;


### PR DESCRIPTION
## Summary
- skip the earliest minute since it normally has no data
- overlay the direction icon on top of the wind speed bar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d2aee8a7c83289c54922390e8bbae