### PR TITLE
Add optional bar autoscaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ The card loads data through the Home Assistant history API and refreshes itself 
   - `gust_entity`
   - `direction_entity`
 - Fallback message when no data is available
+- Optional automatic scaling of bar heights
 
 ## Usage
 
@@ -37,6 +38,8 @@ gust_entity: sensor.wind_gust
 direction_entity: sensor.wind_direction
 # Optional number of minutes (defaults to 30)
 minutes: 45
+# Disable automatic scaling of bars (default: true)
+autoscale: false
 ```
 
 The card will automatically load history and update every minute.

--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -25,6 +25,7 @@ class HaWindStatCard extends LitElement {
     this._config = {
       minutes: 30,
       graph_height: 100,
+      autoscale: true,
       ...config
     };
   }
@@ -191,11 +192,17 @@ class HaWindStatCard extends LitElement {
   }
 
   _renderBar({ wind, gust, direction }, index) {
+    const auto = this._config.autoscale !== false;
+
     const scale = this._maxGust || 1;
     const height = this._config.graph_height;
 
-    const windHeight = Math.round((wind / scale) * height);
-    const gustHeight = Math.max(0, Math.round(((gust - wind) / scale) * height));
+    const windHeight = auto
+      ? Math.round((wind / scale) * height)
+      : Math.round(wind);
+    const gustHeight = auto
+      ? Math.max(0, Math.round(((gust - wind) / scale) * height))
+      : Math.max(0, Math.round(gust - wind));
 
     const colorWind = this._getColor(wind);
     const colorGust = this._getColor(gust);
@@ -232,8 +239,9 @@ class HaWindStatCard extends LitElement {
           ${(() => {
             const scale = this._maxGust || 1;
             const lines = [];
+            const auto = this._config.autoscale !== false;
             for (let v = 5; v <= scale; v += 5) {
-              lines.push(html`<div class="h-line" style="bottom:${(v / scale) * 100}%"></div>`);
+              lines.push(html`<div class="h-line" style="bottom:${auto ? (v / scale) * 100 + '%' : v + 'px'}"></div>`);
             }
             return lines;
           })()}

--- a/info.md
+++ b/info.md
@@ -3,3 +3,4 @@
 A minimal Lovelace card that shows recent wind data as stacked bars. Wind speed forms the base of each bar with gusts stacked above. Data is loaded via the Home Assistant history API, averaged per minute and refreshed automatically every 60 seconds.
 
 Configure the card with `wind_entity`, `gust_entity` and `direction_entity` sensors. See the README for installation and usage instructions.
+Set `autoscale: false` to make bar heights map directly to wind speed (1 kn = 1px).


### PR DESCRIPTION
## Summary
- make bar autoscaling configurable via `autoscale` option
- document new setting in README and info.md

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e1e7850748328883245468df54e45