### PR TITLE
Add multiplier and reposition icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The card loads data through the Home Assistant history API and refreshes itself 
   - `direction_entity`
 - Fallback message when no data is available
 - Optional automatic scaling of bar heights
+- Configurable multiplier for bar height when autoscale is disabled
 
 ## Usage
 
@@ -40,6 +41,8 @@ direction_entity: sensor.wind_direction
 minutes: 45
 # Disable automatic scaling of bars (default: true)
 autoscale: false
+# Multiply raw values by 2 pixels when autoscale is disabled
+multiplier: 2
 ```
 
 The card will automatically load history and update every minute.

--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -26,6 +26,7 @@ class HaWindStatCard extends LitElement {
       minutes: 30,
       graph_height: 100,
       autoscale: true,
+      multiplier: 1,
       ...config
     };
   }
@@ -196,13 +197,14 @@ class HaWindStatCard extends LitElement {
 
     const scale = this._maxGust || 1;
     const height = this._config.graph_height;
+    const multiplier = this._config.multiplier ?? 1;
 
     const windHeight = auto
       ? Math.round((wind / scale) * height)
-      : Math.round(wind);
+      : Math.round(wind * multiplier);
     const gustHeight = auto
       ? Math.max(0, Math.round(((gust - wind) / scale) * height))
-      : Math.max(0, Math.round(gust - wind));
+      : Math.max(0, Math.round((gust - wind) * multiplier));
 
     const colorWind = this._getColor(wind);
     const colorGust = this._getColor(gust);
@@ -240,8 +242,9 @@ class HaWindStatCard extends LitElement {
             const scale = this._maxGust || 1;
             const lines = [];
             const auto = this._config.autoscale !== false;
+            const multiplier = this._config.multiplier ?? 1;
             for (let v = 5; v <= scale; v += 5) {
-              lines.push(html`<div class="h-line" style="bottom:${auto ? (v / scale) * 100 + '%' : v + 'px'}"></div>`);
+              lines.push(html`<div class="h-line" style="bottom:${auto ? (v / scale) * 100 + '%' : v * multiplier + 'px'}"></div>`);
             }
             return lines;
           })()}
@@ -277,7 +280,7 @@ class HaWindStatCard extends LitElement {
     .dir-icon {
       --mdc-icon-size: 100%;
       position: absolute;
-      bottom: 0;
+      bottom: -1em;
       left: 0;
       width: 100%;
       height: 1em;

--- a/info.md
+++ b/info.md
@@ -4,3 +4,4 @@ A minimal Lovelace card that shows recent wind data as stacked bars. Wind speed 
 
 Configure the card with `wind_entity`, `gust_entity` and `direction_entity` sensors. See the README for installation and usage instructions.
 Set `autoscale: false` to make bar heights map directly to wind speed (1 kn = 1px).
+Use `multiplier` to scale the raw bar heights when autoscale is disabled.


### PR DESCRIPTION
## Summary
- allow customizing raw bar height with `multiplier`
- show wind direction icon below the bar
- document new option in README and info

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686e9f950f4c8328a2c51c06a66cbced