### PR TITLE
Refactor row layout to place icon beneath bars

### DIFF
--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -240,13 +240,6 @@ class HaWindStatCard extends LitElement {
 
     return html`
       <div class="wind-bar-segment" style="--icon-size:${this._iconSize}px">
-        <div class="dir-container">
-          <ha-icon
-            class="dir-icon"
-            icon="mdi:navigation"
-            style="transform: rotate(${direction + 180}deg);"
-          ></ha-icon>
-        </div>
         <div
           class="date-wind-bar-segment"
           style="background:${colorWind};height:${windHeight}px;width:100%;"
@@ -257,6 +250,13 @@ class HaWindStatCard extends LitElement {
               style="background:${colorGust};height:1px;margin-bottom:${gustHeight}px;width:100%;"
             ></div>`
           : null}
+        <div class="dir-container">
+          <ha-icon
+            class="dir-icon"
+            icon="mdi:navigation"
+            style="transform: rotate(${direction + 180}deg);"
+          ></ha-icon>
+        </div>
       </div>
     `;
   }
@@ -304,7 +304,7 @@ class HaWindStatCard extends LitElement {
       position: relative;
       width: 100%;
       display: flex;
-      flex-direction: column-reverse;
+      flex-direction: column;
       align-items: stretch;
       transition: height 0.6s ease;
       --icon-size: 0px;
@@ -316,6 +316,9 @@ class HaWindStatCard extends LitElement {
       box-sizing: border-box;
       padding: 1px;
       position: relative;
+      display: flex;
+      align-items: center;
+      justify-content: center;
     }
     .dir-icon {
       --mdc-icon-size: 100%;


### PR DESCRIPTION
## Summary
- rearrange DOM so wind/gust bars are on the first row and direction icon on the second row
- center the direction icon within its row

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ebe2832348328831dd8262ebcd74e