### PR TITLE
Fix bar heights within card

### DIFF
--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -239,7 +239,7 @@ class HaWindStatCard extends LitElement {
     const colorGust = this._getColor(gust);
 
     return html`
-      <div class="wind-bar-segment">
+      <div class="wind-bar-segment" style="--icon-size:${icon}px">
         <div class="dir-container">
           <ha-icon class="dir-icon" icon="mdi:navigation" style="transform: rotate(${direction + 180}deg);">
           </ha-icon>


### PR DESCRIPTION
## Summary
- keep bar height within the card by reserving space for the wind direction icon

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686f6214c1388328a752e9100fcbcfc2