### PR TITLE
Improve wind graph scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The card loads data through the Home Assistant history API and refreshes itself 
 
 - Fetches last N minutes of history (default: 30)
 - Stacked bars showing wind speed with gusts on top
-- Y‑axis from 0–60 kn with grid lines every 5 kn (only up to current max gust)
+- Y‑axis from 0–60 kn with grid lines every 5 kn (graph height rounded up to the next 5 kn)
 - Auto refreshes once per minute and shows the last updated time
 - Direction arrows for each minute showing averaged wind direction
 - Works with three sensors configured in YAML:

--- a/ha-wind-stat-card.js
+++ b/ha-wind-stat-card.js
@@ -190,7 +190,7 @@ class HaWindStatCard extends LitElement {
 
   _renderBar({ wind, gust, direction }) {
     const auto = this._config.autoscale !== false;
-    const scale = this._maxGust || 1;
+    const scale = Math.max(5, Math.ceil((this._maxGust || 1) / 5) * 5);
     const height = this._config.graph_height;
     const multiplier = this._config.multiplier ?? 1;
 
@@ -230,12 +230,16 @@ class HaWindStatCard extends LitElement {
         <div class="graph" style="height:${this._config.graph_height}px">
           <div class="overlay-lines">
             ${(() => {
-              const scale = this._maxGust || 1;
+              const scale = Math.max(5, Math.ceil((this._maxGust || 1) / 5) * 5);
               const lines = [];
               const auto = this._config.autoscale !== false;
               const multiplier = this._config.multiplier ?? 1;
               for (let v = 5; v <= scale; v += 5) {
-                lines.push(html`<div class="h-line" style="bottom:${auto ? (v / scale) * 100 + '%' : v * multiplier + 'px'}"></div>`);
+                const pos = auto ? (v / scale) * 100 + '%' : v * multiplier + 'px';
+                lines.push(html`
+                  <div class="h-line" style="bottom:${pos}">
+                    <span class="h-line-label">${v} kn</span>
+                  </div>`);
               }
               return lines;
             })()}
@@ -299,8 +303,15 @@ class HaWindStatCard extends LitElement {
       position: absolute;
       left: 0;
       width: 100%;
-      height: 1px;
-      background: var(--card-background-color);
+      border-top: 1px solid var(--card-background-color);
+    }
+    .h-line-label {
+      position: absolute;
+      right: 0;
+      top: -8px;
+      font-size: 8px;
+      color: var(--secondary-text-color);
+      padding-right: 2px;
     }
     .date-wind-bar-segment,
     .date-gust-bar-segment {


### PR DESCRIPTION
## Summary
- round graph scale to the next 5 kn
- label horizontal lines with their wind speed value
- document rounded scale in README

## Testing
- `node -c ha-wind-stat-card.js`

------
https://chatgpt.com/codex/tasks/task_e_68721f7a2dd48328a2cc27f149beef0e